### PR TITLE
Increment Python Docker image version from 3.10.4-alpine3.15 to 3.10.6-alpine3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4-alpine3.15
+FROM python:3.10.6-alpine3.16
 
 COPY app.py ./
 


### PR DESCRIPTION
This pull request increases the base [Python Docker image](https://hub.docker.com/_/python) from 3.10.4-alpine3.15 to 3.10.6-alpine3.16.

I tested this change by running the [Getting started](https://github.com/mbigras/hello-world#getting-started) procedure—see terminal output below.

```
$ docker build -t mbigras/hello-world .
# ...
$ docker run -it mbigras/hello-world foo bar baz
hello world!
got args: ['foo', 'bar', 'baz']
$ echo $?
0
```

>**:bulb: Note:** The `echo $?` command prints the exit status of the `docker run -it mbigras/hello-world foo bar baz` command. That's because the `$?` [Bash special parameter](https://www.gnu.org/software/bash/manual/bash.html#Special-Parameters) prints the exit status of the most recent command. By convention, exit status 0 means success and any other number means failure.