### PR TITLE
Upgrade Python from 3.10.6-alpine3.16 to 3.12.0-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.6-alpine3.16
+FROM python:3.12.0-bookworm
 
 COPY app.py ./
 


### PR DESCRIPTION
This pull request upgrades the [_python_](https://hub.docker.com/_/python) Docker image from from _3.10.6-alpine3.16_ to _3.12.0-bookworm_ tag.

I tested this change by running the [_Getting started_](https://github.com/mbigras/hello-world/tree/35fa583bcaf0395e47291053e3d2d013dc9c6f90#getting-started) procedure like the following shell output illustrates:

```
$ docker build --tag hello .
[+] Building 17.9s (8/8) FINISHED                          docker:desktop-linux
# ...
 => => naming to docker.io/library/hello                                   0.0s
$ docker run hello
hello world!
got args: []
$ docker run hello foo bar baz
hello world!
got args: ['foo', 'bar', 'baz']
```
